### PR TITLE
Provides support for configuring Aspects from file. 

### DIFF
--- a/src/iguanaman/thaumcraftmobaspects/AspectPlugin.java
+++ b/src/iguanaman/thaumcraftmobaspects/AspectPlugin.java
@@ -1,0 +1,11 @@
+package iguanaman.thaumcraftmobaspects;
+
+import java.util.HashSet;
+import java.util.List;
+
+public interface AspectPlugin {
+
+	public String[] getRequiredMods();
+
+	public HashSet<ThaumcraftEntity> getThaumcraftMobs();
+}

--- a/src/iguanaman/thaumcraftmobaspects/ModFileCache.java
+++ b/src/iguanaman/thaumcraftmobaspects/ModFileCache.java
@@ -1,0 +1,120 @@
+package iguanaman.thaumcraftmobaspects;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import net.minecraft.entity.EntityList;
+import net.minecraft.entity.EntityLiving;
+
+import com.google.common.base.CharMatcher;
+import com.google.common.base.Optional;
+
+public class ModFileCache {
+	// Used for Manually Mapping ModId to entities
+	private HashMap<String, String> entityPackageToPrefix = new HashMap<String, String>(5);
+	public static final String UNKNOWN_CATEGORY = "unknown";
+	public static final String PLAYER_CATEGORY = "unknown";
+	public static final String CONFIG_FOLDER = "ThaumcraftMobAspects";
+	private final File configDirectory;
+
+	private HashMap<String, File> localPathToFile = new HashMap<String, File>();;
+
+	public ModFileCache(File configDirectory)
+	{
+		this.configDirectory = configDirectory;
+		entityPackageToPrefix.put("net.minecraft.entity.boss", "vanilla");
+		entityPackageToPrefix.put("net.minecraft.entity.monster", "vanilla");
+		entityPackageToPrefix.put("net.minecraft.entity.passive", "vanilla");
+		entityPackageToPrefix.put("net.minecraft.entity.item", "vanillaitem");
+		entityPackageToPrefix.put("net.minecraft.entity.player", PLAYER_CATEGORY);
+	}
+
+	public Optional<File> getFile(String modId)
+	{
+		modId = filterModIdToValidCharacters(modId);
+		try
+		{
+			File modFile = localPathToFile.get(modId);
+			if (modFile == null)
+			{
+				modFile = new File(configDirectory, CONFIG_FOLDER + "/" + modId + ".cfg");
+				modFile.getParentFile().mkdirs();
+				modFile.createNewFile();
+				localPathToFile.put(modId, modFile);
+			}
+			return Optional.of(modFile);
+		} catch (IOException e)
+		{
+			e.printStackTrace();
+		}
+		return Optional.absent();
+	}
+
+	private String filterModIdToValidCharacters(String modId)
+	{
+		return CharMatcher.anyOf("qwertyuiopasdfghjklzxcvbnm0QWERTYUIOPASDFGHJKLZXCVBNM123456789").retainFrom(modId);
+	}
+
+	public HashSet<String> getModIds()
+	{
+		HashSet<String> modIds = new HashSet<String>();
+		for (Object object : EntityList.stringToClassMapping.keySet())
+		{
+			String entityName = (String) object;
+			modIds.add(guessModId(entityName));
+		}
+		modIds.add(PLAYER_CATEGORY);
+		return modIds;
+	}
+
+	public String guessModId(String entityName)
+	{
+
+		if (entityName.contains("."))
+		{
+			return entityName.split("\\.")[0];
+		} else
+		{
+			Class<?> entityClass = ((Class<?>) EntityList.stringToClassMapping.get(entityName));
+			if (entityClass == null)
+			{
+				return UNKNOWN_CATEGORY;
+			}
+			// Search for other entities having the same package that are mod specific
+			String packageNeedingId = entityClass.getName();
+
+			if (packageNeedingId.lastIndexOf(".") != -1)
+			{
+				// Remove Entity Name (i.e. net.minecraft.bear to net.minecraft)
+				packageNeedingId = packageNeedingId.substring(0, packageNeedingId.lastIndexOf("."));
+			}
+			Set<Entry<Class<?>, String>> fmlNames = EntityList.classToStringMapping.entrySet();
+			for (Entry<Class<?>, String> entry : fmlNames)
+			{
+				String packageName = entry.getKey().getName();
+				if (packageName.lastIndexOf(".") != -1)
+				{
+					packageName = packageName.substring(0, packageName.lastIndexOf("."));
+				}
+				// If package is equal to packageNeedingId use ModId if it has one
+				if (packageNeedingId.equals(packageName) && entry.getValue().contains("."))
+				{
+					return entry.getValue().split("\\.")[0];
+				}
+			}
+
+			String manualPrefix = entityPackageToPrefix.get(packageNeedingId);
+			if (manualPrefix != null)
+			{
+				return manualPrefix;
+			}
+			// If all else fails, assumed that the ModId is the first part of the package name
+			String[] currentParts = packageNeedingId.split("\\.");
+			return currentParts.length > 1 ? currentParts[0] : UNKNOWN_CATEGORY;
+		}
+	}
+}

--- a/src/iguanaman/thaumcraftmobaspects/PluginLycanitesMobs.java
+++ b/src/iguanaman/thaumcraftmobaspects/PluginLycanitesMobs.java
@@ -1,38 +1,53 @@
 package iguanaman.thaumcraftmobaspects;
 
+import java.util.HashSet;
+
 import cpw.mods.fml.common.Loader;
 import thaumcraft.api.ThaumcraftApi;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
+import iguanaman.thaumcraftmobaspects.ThaumcraftMobAspects;
 
-public class PluginLycanitesMobs {
+public class PluginLycanitesMobs implements AspectPlugin {
 
-	public static void init()
+	@Override
+	public String[] getRequiredMods()
 	{
+		return new String[]
+		{ "LycanitesMobs" };
+	}
 
-		if (Loader.isModLoaded("LycanitesMobs"))
-		{
-			// DEMON
-			ThaumcraftApi.registerEntityTag("Asmodi", new AspectList().add(Aspect.METAL, 3).add(Aspect.MECHANISM, 2).add(Aspect.MIND, 1).add(Aspect.ENTROPY, 1));
-			ThaumcraftApi.registerEntityTag("Behemoth", creatureAspects(4, Aspect.FIRE).add(Aspect.ENTROPY, 1));
-			ThaumcraftApi.registerEntityTag("Belph", new AspectList().add(Aspect.FIRE, 2).add(Aspect.MAGIC, 1).add(Aspect.ENTROPY, 1));
-			ThaumcraftApi.registerEntityTag("Cacodemon", new AspectList().add(Aspect.FLIGHT, 3).add(Aspect.AIR, 3).add(Aspect.ENERGY, 2).add(Aspect.ENTROPY, 1));
-			ThaumcraftApi.registerEntityTag("NetherSoul", new AspectList().add(Aspect.FLIGHT, 2).add(Aspect.AIR, 2).add(Aspect.FIRE, 2).add(Aspect.ENERGY, 1));
-			ThaumcraftApi.registerEntityTag("Pinky", new AspectList().add(Aspect.HUNGER, 2).add(Aspect.FLESH, 2).add(Aspect.GREED, 2));
-			ThaumcraftApi.registerEntityTag("Trite", creatureAspects(2, Aspect.ENTROPY));
-			
-			// DESERT
-			ThaumcraftApi.registerEntityTag("CryptZombie", new AspectList().add(Aspect.UNDEAD, 2).add(Aspect.MAN, 1).add(Aspect.EARTH, 1).add(Aspect.CLOTH, 1));
-			
-			// SWAMP
-			ThaumcraftApi.registerEntityTag("GhoulZombie", new AspectList().add(Aspect.UNDEAD, 2).add(Aspect.MAN, 1).add(Aspect.EARTH, 1).add(Aspect.POISON, 1));
-		}
-		
-	}	
-    
-    public static AspectList creatureAspects(int size, Aspect... aspects)
-    {
-    	return ThaumcraftMobAspects.creatureAspects(size, aspects);
-    }
+	@Override
+	public HashSet<ThaumcraftEntity> getThaumcraftMobs()
+	{
+		HashSet<ThaumcraftEntity> mobs = new HashSet<ThaumcraftEntity>();
+		// DEMON
+		mobs.add(new ThaumcraftEntity("Asmodi", new AspectList().add(Aspect.METAL, 3).add(Aspect.MECHANISM, 2)
+				.add(Aspect.MIND, 1).add(Aspect.ENTROPY, 1)));
+		mobs.add(new ThaumcraftEntity("Behemoth", creatureAspects(4, Aspect.FIRE).add(Aspect.ENTROPY, 1)));
+		mobs.add(new ThaumcraftEntity("Belph", new AspectList().add(Aspect.FIRE, 2).add(Aspect.MAGIC, 1)
+				.add(Aspect.ENTROPY, 1)));
+		mobs.add(new ThaumcraftEntity("Cacodemon", new AspectList().add(Aspect.FLIGHT, 3).add(Aspect.AIR, 3)
+				.add(Aspect.ENERGY, 2).add(Aspect.ENTROPY, 1)));
+		mobs.add(new ThaumcraftEntity("NetherSoul", new AspectList().add(Aspect.FLIGHT, 2).add(Aspect.AIR, 2)
+				.add(Aspect.FIRE, 2).add(Aspect.ENERGY, 1)));
+		mobs.add(new ThaumcraftEntity("Pinky", new AspectList().add(Aspect.HUNGER, 2).add(Aspect.FLESH, 2)
+				.add(Aspect.GREED, 2)));
+		mobs.add(new ThaumcraftEntity("Trite", creatureAspects(2, Aspect.ENTROPY)));
 
+		// DESERT
+		mobs.add(new ThaumcraftEntity("CryptZombie", new AspectList().add(Aspect.UNDEAD, 2).add(Aspect.MAN, 1)
+				.add(Aspect.EARTH, 1).add(Aspect.CLOTH, 1)));
+
+		// SWAMP
+		mobs.add(new ThaumcraftEntity("GhoulZombie", new AspectList().add(Aspect.UNDEAD, 2).add(Aspect.MAN, 1)
+				.add(Aspect.EARTH, 1).add(Aspect.POISON, 1)));
+
+		return mobs;
+	}
+
+	public static AspectList creatureAspects(int size, Aspect... aspects)
+	{
+		return ThaumcraftMobAspects.creatureAspects(size, aspects);
+	}
 }

--- a/src/iguanaman/thaumcraftmobaspects/PluginMoCreatures.java
+++ b/src/iguanaman/thaumcraftmobaspects/PluginMoCreatures.java
@@ -1,80 +1,102 @@
 package iguanaman.thaumcraftmobaspects;
 
+import java.util.HashSet;
+
 import cpw.mods.fml.common.Loader;
 import thaumcraft.api.ThaumcraftApi;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
 
-public class PluginMoCreatures {
+public class PluginMoCreatures implements AspectPlugin {
 
-	public static void init()
+	@Override
+	public String[] getRequiredMods()
 	{
+		return new String[]
+		{ "MoCreatures" };
+	}
 
-		if (Loader.isModLoaded("MoCreatures"))
-		{
-			ThaumcraftApi.registerEntityTag("MoCreatures.Ant", creatureAspects(1, Aspect.EARTH));
-			ThaumcraftApi.registerEntityTag("MoCreatures.Bear", creatureAspects(3, Aspect.EARTH));
-			ThaumcraftApi.registerEntityTag("MoCreatures.Bee", creatureAspects(1, Aspect.AIR, Aspect.FLIGHT));
-			ThaumcraftApi.registerEntityTag("MoCreatures.BigCat", creatureAspects(3, Aspect.EARTH));
-			ThaumcraftApi.registerEntityTag("MoCreatures.BigGolem", new AspectList().add(Aspect.METAL, 4).add(Aspect.MECHANISM, 2).add(Aspect.GREED, 1));
-			ThaumcraftApi.registerEntityTag("MoCreatures.Bird", creatureAspects(1, Aspect.AIR, Aspect.FLIGHT));
-			ThaumcraftApi.registerEntityTag("MoCreatures.Boar", creatureAspects(2, Aspect.EARTH).add(Aspect.WEAPON, 1));
-			ThaumcraftApi.registerEntityTag("MoCreatures.Bunny", creatureAspects(2, Aspect.EARTH));
-			ThaumcraftApi.registerEntityTag("MoCreatures.ButterFly", creatureAspects(1, Aspect.AIR, Aspect.FLIGHT));
-			ThaumcraftApi.registerEntityTag("MoCreatures.Crab", creatureAspects(2, Aspect.EARTH, Aspect.WATER));
-			ThaumcraftApi.registerEntityTag("MoCreatures.Cricket", creatureAspects(1, Aspect.EARTH));
-			ThaumcraftApi.registerEntityTag("MoCreatures.Crocodile", creatureAspects(3, Aspect.WATER, Aspect.EARTH));
-			ThaumcraftApi.registerEntityTag("MoCreatures.Deer", creatureAspects(2, Aspect.EARTH));
-			ThaumcraftApi.registerEntityTag("MoCreatures.Dolphin", creatureAspects(3, Aspect.WATER));
-			ThaumcraftApi.registerEntityTag("MoCreatures.DragonFly", creatureAspects(1, Aspect.AIR, Aspect.FLIGHT));
-			ThaumcraftApi.registerEntityTag("MoCreatures.Duck", creatureAspects(2, Aspect.EARTH, Aspect.FLIGHT));
-			ThaumcraftApi.registerEntityTag("MoCreatures.Egg", new AspectList().add(Aspect.SEED, 1).add(Aspect.LIFE, 1).add(Aspect.BEAST, 1));
-			ThaumcraftApi.registerEntityTag("MoCreatures.Elephant", creatureAspects(4, Aspect.EARTH));
-			ThaumcraftApi.registerEntityTag("MoCreatures.Firefly", creatureAspects(1, Aspect.AIR, Aspect.FLIGHT));
-			ThaumcraftApi.registerEntityTag("MoCreatures.Fishbowl", new AspectList().add(Aspect.WATER, 1).add(Aspect.CRYSTAL, 1));
-			ThaumcraftApi.registerEntityTag("MoCreatures.Fishy", creatureAspects(1, Aspect.WATER));
-			ThaumcraftApi.registerEntityTag("MoCreatures.FlameWraith", new AspectList().add(Aspect.SOUL, 3).add(Aspect.FIRE, 3));
-			ThaumcraftApi.registerEntityTag("MoCreatures.Fly", creatureAspects(1, Aspect.AIR, Aspect.FLIGHT));
-			ThaumcraftApi.registerEntityTag("MoCreatures.Fox", creatureAspects(2, Aspect.EARTH));
-			ThaumcraftApi.registerEntityTag("MoCreatures.Goat", creatureAspects(2, Aspect.EARTH));
-			ThaumcraftApi.registerEntityTag("MoCreatures.HellRat", new AspectList().add(Aspect.BEAST, 2).add(Aspect.FIRE, 1));
-			ThaumcraftApi.registerEntityTag("MoCreatures.HorseMob", new AspectList().add(Aspect.UNDEAD, 3).add(Aspect.EARTH, 1).add(Aspect.AIR, 1));
-			ThaumcraftApi.registerEntityTag("MoCreatures.JellyFish", creatureAspects(2, Aspect.WATER));
-			ThaumcraftApi.registerEntityTag("MoCreatures.Kitty", creatureAspects(2, Aspect.EARTH));
-			ThaumcraftApi.registerEntityTag("MoCreatures.KittyBed", new AspectList().add(Aspect.CLOTH, 1).add(Aspect.TREE, 1));
-			ThaumcraftApi.registerEntityTag("MoCreatures.KomodoDragon", new AspectList().add(Aspect.BEAST, 3).add(Aspect.POISON, 2));
-			ThaumcraftApi.registerEntityTag("MoCreatures.LitterBox", new AspectList().add(Aspect.EARTH, 1).add(Aspect.TREE, 1));
-			ThaumcraftApi.registerEntityTag("MoCreatures.Maggot", creatureAspects(1, Aspect.EARTH, Aspect.ENTROPY));
-			ThaumcraftApi.registerEntityTag("MoCreatures.MediumFish", creatureAspects(2, Aspect.WATER));
-			ThaumcraftApi.registerEntityTag("MoCreatures.MiniGolem", new AspectList().add(Aspect.METAL, 2).add(Aspect.MECHANISM, 1).add(Aspect.GREED, 1));
-			ThaumcraftApi.registerEntityTag("MoCreatures.Mouse", creatureAspects(1, Aspect.EARTH));
-			ThaumcraftApi.registerEntityTag("MoCreatures.Ogre", new AspectList().add(Aspect.BEAST, 4).add(Aspect.DARKNESS, 3));
-			ThaumcraftApi.registerEntityTag("MoCreatures.Ostrich", creatureAspects(2, Aspect.EARTH));
-			ThaumcraftApi.registerEntityTag("MoCreatures.PetScorpion", new AspectList().add(Aspect.BEAST, 3).add(Aspect.WEAPON, 1).add(Aspect.POISON, 1));
-			ThaumcraftApi.registerEntityTag("MoCreatures.Piranha", creatureAspects(1, Aspect.WATER));
-			ThaumcraftApi.registerEntityTag("MoCreatures.Raccoon", creatureAspects(2, Aspect.EARTH));
-			ThaumcraftApi.registerEntityTag("MoCreatures.Rat", creatureAspects(2, Aspect.EARTH));
-			ThaumcraftApi.registerEntityTag("MoCreatures.Ray", creatureAspects(2, Aspect.WATER));
-			ThaumcraftApi.registerEntityTag("MoCreatures.Roach", creatureAspects(1, Aspect.EARTH, Aspect.ENTROPY));
-			ThaumcraftApi.registerEntityTag("MoCreatures.Scorpion", new AspectList().add(Aspect.BEAST, 3).add(Aspect.WEAPON, 1).add(Aspect.POISON, 1));
-			ThaumcraftApi.registerEntityTag("MoCreatures.Shark", creatureAspects(3, Aspect.WATER));
-			ThaumcraftApi.registerEntityTag("MoCreatures.SilverSkeleton", new AspectList().add(Aspect.UNDEAD, 3).add(Aspect.METAL, 1).add(Aspect.ARMOR, 1));
-			ThaumcraftApi.registerEntityTag("MoCreatures.SmallFish", creatureAspects(1, Aspect.WATER));
-			ThaumcraftApi.registerEntityTag("MoCreatures.Snail", creatureAspects(1, Aspect.SLIME));
-			ThaumcraftApi.registerEntityTag("MoCreatures.Snake", creatureAspects(2, Aspect.EARTH));
-			ThaumcraftApi.registerEntityTag("MoCreatures.Turkey", creatureAspects(2, Aspect.FLIGHT, Aspect.EARTH));
-			ThaumcraftApi.registerEntityTag("MoCreatures.Turtle", creatureAspects(2, Aspect.EARTH));
-			ThaumcraftApi.registerEntityTag("MoCreatures.WWolf", creatureAspects(3, Aspect.EARTH));
-			ThaumcraftApi.registerEntityTag("MoCreatures.Werewolf", new AspectList().add(Aspect.BEAST, 3).add(Aspect.MAN, 3));
-			ThaumcraftApi.registerEntityTag("MoCreatures.WildHorse", new AspectList().add(Aspect.BEAST, 4).add(Aspect.EARTH, 1).add(Aspect.AIR, 1));
-			ThaumcraftApi.registerEntityTag("MoCreatures.Wraith", new AspectList().add(Aspect.SOUL, 3).add(Aspect.ENTROPY, 3));
-			ThaumcraftApi.registerEntityTag("MoCreatures.Wyvern", new AspectList().add(Aspect.BEAST, 5).add(Aspect.FLIGHT, 3).add(Aspect.AIR, 3));
-		}
-	}	
-    
-    public static AspectList creatureAspects(int size, Aspect... aspects)
-    {
-    	return ThaumcraftMobAspects.creatureAspects(size, aspects);
-    }
+	@Override
+	public HashSet<ThaumcraftEntity> getThaumcraftMobs()
+	{
+		HashSet<ThaumcraftEntity> mobs = new HashSet<ThaumcraftEntity>();
+		mobs.add(new ThaumcraftEntity("MoCreatures.Ant", creatureAspects(1, Aspect.EARTH)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.Ant", creatureAspects(1, Aspect.EARTH)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.Bear", creatureAspects(3, Aspect.EARTH)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.Bee", creatureAspects(1, Aspect.AIR, Aspect.FLIGHT)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.BigCat", creatureAspects(3, Aspect.EARTH)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.BigGolem", new AspectList().add(Aspect.METAL, 4)
+				.add(Aspect.MECHANISM, 2).add(Aspect.GREED, 1)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.Bird", creatureAspects(1, Aspect.AIR, Aspect.FLIGHT)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.Boar", creatureAspects(2, Aspect.EARTH).add(Aspect.WEAPON, 1)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.Bunny", creatureAspects(2, Aspect.EARTH)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.ButterFly", creatureAspects(1, Aspect.AIR, Aspect.FLIGHT)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.Crab", creatureAspects(2, Aspect.EARTH, Aspect.WATER)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.Cricket", creatureAspects(1, Aspect.EARTH)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.Crocodile", creatureAspects(3, Aspect.WATER, Aspect.EARTH)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.Deer", creatureAspects(2, Aspect.EARTH)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.Dolphin", creatureAspects(3, Aspect.WATER)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.DragonFly", creatureAspects(1, Aspect.AIR, Aspect.FLIGHT)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.Duck", creatureAspects(2, Aspect.EARTH, Aspect.FLIGHT)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.Egg", new AspectList().add(Aspect.SEED, 1).add(Aspect.LIFE, 1)
+				.add(Aspect.BEAST, 1)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.Elephant", creatureAspects(4, Aspect.EARTH)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.Firefly", creatureAspects(1, Aspect.AIR, Aspect.FLIGHT)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.Fishbowl", new AspectList().add(Aspect.WATER, 1).add(Aspect.CRYSTAL,
+				1)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.Fishy", creatureAspects(1, Aspect.WATER)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.FlameWraith", new AspectList().add(Aspect.SOUL, 3).add(Aspect.FIRE,
+				3)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.Fly", creatureAspects(1, Aspect.AIR, Aspect.FLIGHT)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.Fox", creatureAspects(2, Aspect.EARTH)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.Goat", creatureAspects(2, Aspect.EARTH)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.HellRat", new AspectList().add(Aspect.BEAST, 2).add(Aspect.FIRE, 1)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.HorseMob", new AspectList().add(Aspect.UNDEAD, 3)
+				.add(Aspect.EARTH, 1).add(Aspect.AIR, 1)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.JellyFish", creatureAspects(2, Aspect.WATER)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.Kitty", creatureAspects(2, Aspect.EARTH)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.KittyBed", new AspectList().add(Aspect.CLOTH, 1).add(Aspect.TREE, 1)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.KomodoDragon", new AspectList().add(Aspect.BEAST, 3).add(
+				Aspect.POISON, 2)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.LitterBox", new AspectList().add(Aspect.EARTH, 1)
+				.add(Aspect.TREE, 1)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.Maggot", creatureAspects(1, Aspect.EARTH, Aspect.ENTROPY)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.MediumFish", creatureAspects(2, Aspect.WATER)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.MiniGolem", new AspectList().add(Aspect.METAL, 2)
+				.add(Aspect.MECHANISM, 1).add(Aspect.GREED, 1)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.Mouse", creatureAspects(1, Aspect.EARTH)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.Ogre", new AspectList().add(Aspect.BEAST, 4).add(Aspect.DARKNESS, 3)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.Ostrich", creatureAspects(2, Aspect.EARTH)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.PetScorpion", new AspectList().add(Aspect.BEAST, 3)
+				.add(Aspect.WEAPON, 1).add(Aspect.POISON, 1)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.Piranha", creatureAspects(1, Aspect.WATER)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.Raccoon", creatureAspects(2, Aspect.EARTH)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.Rat", creatureAspects(2, Aspect.EARTH)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.Ray", creatureAspects(2, Aspect.WATER)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.Roach", creatureAspects(1, Aspect.EARTH, Aspect.ENTROPY)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.Scorpion", new AspectList().add(Aspect.BEAST, 3)
+				.add(Aspect.WEAPON, 1).add(Aspect.POISON, 1)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.Shark", creatureAspects(3, Aspect.WATER)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.SilverSkeleton", new AspectList().add(Aspect.UNDEAD, 3)
+				.add(Aspect.METAL, 1).add(Aspect.ARMOR, 1)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.SmallFish", creatureAspects(1, Aspect.WATER)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.Snail", creatureAspects(1, Aspect.SLIME)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.Snake", creatureAspects(2, Aspect.EARTH)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.Turkey", creatureAspects(2, Aspect.FLIGHT, Aspect.EARTH)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.Turtle", creatureAspects(2, Aspect.EARTH)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.WWolf", creatureAspects(3, Aspect.EARTH)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.Werewolf", new AspectList().add(Aspect.BEAST, 3).add(Aspect.MAN, 3)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.WildHorse", new AspectList().add(Aspect.BEAST, 4)
+				.add(Aspect.EARTH, 1).add(Aspect.AIR, 1)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.Wraith", new AspectList().add(Aspect.SOUL, 3).add(Aspect.ENTROPY, 3)));
+		mobs.add(new ThaumcraftEntity("MoCreatures.Wyvern", new AspectList().add(Aspect.BEAST, 5).add(Aspect.FLIGHT, 3)
+				.add(Aspect.AIR, 3)));
+		return mobs;
+	}
+
+	public static AspectList creatureAspects(int size, Aspect... aspects)
+	{
+		return ThaumcraftMobAspects.creatureAspects(size, aspects);
+	}
 
 }

--- a/src/iguanaman/thaumcraftmobaspects/PluginSpecialMobs.java
+++ b/src/iguanaman/thaumcraftmobaspects/PluginSpecialMobs.java
@@ -1,107 +1,118 @@
 package iguanaman.thaumcraftmobaspects;
 
+import java.util.HashSet;
+
 import cpw.mods.fml.common.Loader;
 import thaumcraft.api.ThaumcraftApi;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
 
-public class PluginSpecialMobs {
+public class PluginSpecialMobs implements AspectPlugin {
 
-	public static void init()
+	@Override
+	public String[] getRequiredMods()
 	{
+		return new String[]
+		{ "SpecialMobs" };
+	}
 
-		if (Loader.isModLoaded("SpecialMobs"))
-		{
+	@Override
+	public HashSet<ThaumcraftEntity> getThaumcraftMobs()
+	{
+		HashSet<ThaumcraftEntity> mobs = new HashSet<ThaumcraftEntity>();
+		AspectList creeperAspects = new AspectList().add(Aspect.PLANT, 2).add(Aspect.FIRE, 2);
+		mobs.add(new ThaumcraftEntity("SpecialMobs.ArmorCreeper", creeperAspects.add(Aspect.ARMOR, 1)));
+		mobs.add(new ThaumcraftEntity("SpecialMobs.DeathCreeper", creeperAspects.add(Aspect.DEATH, 1)));
+		mobs.add(new ThaumcraftEntity("SpecialMobs.DirtCreeper", creeperAspects.add(Aspect.EARTH, 1)));
+		mobs.add(new ThaumcraftEntity("SpecialMobs.DoomCreeper", creeperAspects.add(Aspect.ENERGY, 1)));
+		mobs.add(new ThaumcraftEntity("SpecialMobs.EnderCreeper", creeperAspects.add(Aspect.ELDRITCH, 1)));
+		mobs.add(new ThaumcraftEntity("SpecialMobs.FireCreeper", creeperAspects.add(Aspect.FIRE, 1)));
+		mobs.add(new ThaumcraftEntity("SpecialMobs.JumpingCreeper", creeperAspects.add(Aspect.AIR, 1)));
+		mobs.add(new ThaumcraftEntity("SpecialMobs.LightningCreeper", creeperAspects.add(Aspect.WEATHER, 1)));
+		mobs.add(new ThaumcraftEntity("SpecialMobs.SpecialCreeper", creeperAspects));
 
-			//CREEPERS
-			AspectList creeperAspects = new AspectList().add(Aspect.PLANT, 2).add(Aspect.FIRE, 2);
-			ThaumcraftApi.registerEntityTag("SpecialMobs.ArmorCreeper", creeperAspects.add(Aspect.ARMOR, 1));
-			ThaumcraftApi.registerEntityTag("SpecialMobs.DeathCreeper", creeperAspects.add(Aspect.DEATH, 1));
-			ThaumcraftApi.registerEntityTag("SpecialMobs.DirtCreeper", creeperAspects.add(Aspect.EARTH, 1));
-			ThaumcraftApi.registerEntityTag("SpecialMobs.DoomCreeper", creeperAspects.add(Aspect.ENERGY, 1));
-			ThaumcraftApi.registerEntityTag("SpecialMobs.EnderCreeper", creeperAspects.add(Aspect.ELDRITCH, 1));
-			ThaumcraftApi.registerEntityTag("SpecialMobs.FireCreeper", creeperAspects.add(Aspect.FIRE, 1));
-			ThaumcraftApi.registerEntityTag("SpecialMobs.JumpingCreeper", creeperAspects.add(Aspect.AIR, 1));
-			ThaumcraftApi.registerEntityTag("SpecialMobs.LightningCreeper", creeperAspects.add(Aspect.WEATHER, 1));
-			ThaumcraftApi.registerEntityTag("SpecialMobs.SpecialCreeper", creeperAspects);
+		// ENDERMEN
+		AspectList endermanAspects = new AspectList().add(Aspect.ELDRITCH, 4).add(Aspect.AIR, 2).add(Aspect.TRAVEL, 2);
+		mobs.add(new ThaumcraftEntity("SpecialMobs.AncientEnderman", endermanAspects.add(Aspect.ELDRITCH, 1)));
+		mobs.add(new ThaumcraftEntity("SpecialMobs.BlindingEnderman", endermanAspects.add(Aspect.DARKNESS, 1)));
+		mobs.add(new ThaumcraftEntity("SpecialMobs.ConfusingEnderman", endermanAspects.add(Aspect.SENSES, 1)));
+		mobs.add(new ThaumcraftEntity("SpecialMobs.CursedEnderman", endermanAspects.add(Aspect.SOUL, 1)));
+		mobs.add(new ThaumcraftEntity("SpecialMobs.IcyEnderman", endermanAspects.add(Aspect.ICE, 1)));
+		mobs.add(new ThaumcraftEntity("SpecialMobs.LightningEnderman", endermanAspects.add(Aspect.WEATHER, 1)));
+		mobs.add(new ThaumcraftEntity("SpecialMobs.MirageEnderman", endermanAspects.add(Aspect.VOID, 1)));
+		mobs.add(new ThaumcraftEntity("SpecialMobs.SpecialEnderman", endermanAspects));
+		mobs.add(new ThaumcraftEntity("SpecialMobs.StrikeEnderman", endermanAspects.add(Aspect.ARMOR, 1)));
 
-			//ENDERMEN
-			AspectList endermanAspects = new AspectList().add(Aspect.ELDRITCH, 4).add(Aspect.AIR, 2).add(Aspect.TRAVEL, 2);
-			ThaumcraftApi.registerEntityTag("SpecialMobs.AncientEnderman", endermanAspects.add(Aspect.ELDRITCH, 1));
-			ThaumcraftApi.registerEntityTag("SpecialMobs.BlindingEnderman", endermanAspects.add(Aspect.DARKNESS, 1));
-			ThaumcraftApi.registerEntityTag("SpecialMobs.ConfusingEnderman", endermanAspects.add(Aspect.SENSES, 1));
-			ThaumcraftApi.registerEntityTag("SpecialMobs.CursedEnderman", endermanAspects.add(Aspect.SOUL, 1));
-			ThaumcraftApi.registerEntityTag("SpecialMobs.IcyEnderman", endermanAspects.add(Aspect.ICE, 1));
-			ThaumcraftApi.registerEntityTag("SpecialMobs.LightningEnderman", endermanAspects.add(Aspect.WEATHER, 1));
-			ThaumcraftApi.registerEntityTag("SpecialMobs.MirageEnderman", endermanAspects.add(Aspect.VOID, 1));
-			ThaumcraftApi.registerEntityTag("SpecialMobs.SpecialEnderman", endermanAspects);
-			ThaumcraftApi.registerEntityTag("SpecialMobs.StrikeEnderman", endermanAspects.add(Aspect.ARMOR, 1));
+		// GHASTS
+		AspectList ghastAspects = new AspectList().add(Aspect.UNDEAD, 2).add(Aspect.FIRE, 2);
+		mobs.add(new ThaumcraftEntity("SpecialMobs.BabyGhast", new AspectList().add(Aspect.UNDEAD, 1).add(Aspect.FIRE,
+				1)));
+		mobs.add(new ThaumcraftEntity("SpecialMobs.FighterGhast", ghastAspects));
+		mobs.add(new ThaumcraftEntity("SpecialMobs.GhastMount", ghastAspects));
+		mobs.add(new ThaumcraftEntity("SpecialMobs.KingGhast", ghastAspects.add(Aspect.UNDEAD, 1).add(Aspect.FIRE, 1)));
+		mobs.add(new ThaumcraftEntity("SpecialMobs.QueenGhast", ghastAspects.add(Aspect.UNDEAD, 2).add(Aspect.FIRE, 2)));
+		mobs.add(new ThaumcraftEntity("SpecialMobs.SpecialGhast", ghastAspects));
 
-			//GHASTS
-			AspectList ghastAspects = new AspectList().add(Aspect.UNDEAD, 2).add(Aspect.FIRE, 2);
-			ThaumcraftApi.registerEntityTag("SpecialMobs.BabyGhast", new AspectList().add(Aspect.UNDEAD, 1).add(Aspect.FIRE, 1));
-			ThaumcraftApi.registerEntityTag("SpecialMobs.FighterGhast", ghastAspects);
-			ThaumcraftApi.registerEntityTag("SpecialMobs.GhastMount", ghastAspects);
-			ThaumcraftApi.registerEntityTag("SpecialMobs.KingGhast", ghastAspects.add(Aspect.UNDEAD, 1).add(Aspect.FIRE, 1));
-			ThaumcraftApi.registerEntityTag("SpecialMobs.QueenGhast", ghastAspects.add(Aspect.UNDEAD, 2).add(Aspect.FIRE, 2));
-			ThaumcraftApi.registerEntityTag("SpecialMobs.SpecialGhast", ghastAspects);
-			
-			//SKELETONS
-			AspectList skeletonAspects = new AspectList().add(Aspect.UNDEAD, 3).add(Aspect.MAN, 1).add(Aspect.EARTH, 1);
-			ThaumcraftApi.registerEntityTag("SpecialMobs.FireSkeleton", skeletonAspects.add(Aspect.FIRE, 1));
-			ThaumcraftApi.registerEntityTag("SpecialMobs.GatlingSkeleton", skeletonAspects.add(Aspect.MECHANISM, 1));
-			ThaumcraftApi.registerEntityTag("SpecialMobs.GiantSkeleton", new AspectList().add(Aspect.UNDEAD, 6).add(Aspect.MAN, 2).add(Aspect.EARTH, 2));
-			ThaumcraftApi.registerEntityTag("SpecialMobs.PoisonSkeleton", skeletonAspects.add(Aspect.POISON, 1));
-			ThaumcraftApi.registerEntityTag("SpecialMobs.QuickSkeleton", skeletonAspects.add(Aspect.MOTION, 1));
-			ThaumcraftApi.registerEntityTag("SpecialMobs.SpecialSkeleton", skeletonAspects);
-			ThaumcraftApi.registerEntityTag("SpecialMobs.SpitfireSkeleton", skeletonAspects);
-			ThaumcraftApi.registerEntityTag("SpecialMobs.ThiefSkeleton", skeletonAspects.add(Aspect.GREED, 1));
-			
-			//SPIDERS
-			AspectList spiderAspects = new AspectList().add(Aspect.BEAST, 3).add(Aspect.ENTROPY, 2);
-			ThaumcraftApi.registerEntityTag("SpecialMobs.AngrySpider", spiderAspects.add(Aspect.ENTROPY, 1));
-			ThaumcraftApi.registerEntityTag("SpecialMobs.ArmorSpider", spiderAspects.add(Aspect.ARMOR, 1));
-			ThaumcraftApi.registerEntityTag("SpecialMobs.BabySpider", new AspectList().add(Aspect.BEAST, 1).add(Aspect.ENTROPY, 1));
-			ThaumcraftApi.registerEntityTag("SpecialMobs.DesertSpider", spiderAspects.add(Aspect.EARTH, 1));
-			ThaumcraftApi.registerEntityTag("SpecialMobs.FlyingSpider", spiderAspects.add(Aspect.FLIGHT, 1));
-			ThaumcraftApi.registerEntityTag("SpecialMobs.GiantSpider", new AspectList().add(Aspect.BEAST, 4).add(Aspect.ENTROPY, 3));
-			ThaumcraftApi.registerEntityTag("SpecialMobs.MotherSpider", spiderAspects.add(Aspect.HEAL, 1));
-			ThaumcraftApi.registerEntityTag("SpecialMobs.PaleSpider", spiderAspects.add(Aspect.POISON, 1));
-			ThaumcraftApi.registerEntityTag("SpecialMobs.PoisonSpider", spiderAspects.add(Aspect.POISON, 1));
-			ThaumcraftApi.registerEntityTag("SpecialMobs.SmallSpider", new AspectList().add(Aspect.BEAST, 2).add(Aspect.ENTROPY, 1));
-			ThaumcraftApi.registerEntityTag("SpecialMobs.SpecialSpider", spiderAspects);
-			ThaumcraftApi.registerEntityTag("SpecialMobs.SpeedySpider", spiderAspects.add(Aspect.MOTION, 1));
-			ThaumcraftApi.registerEntityTag("SpecialMobs.ToughSpider", spiderAspects.add(Aspect.LIFE, 1));
-			ThaumcraftApi.registerEntityTag("SpecialMobs.WitchSpider", spiderAspects.add(Aspect.MAGIC, 1));
-			
-			//ZOMBIES
-			AspectList zombieAspects = new AspectList().add(Aspect.UNDEAD, 2).add(Aspect.MAN, 1).add(Aspect.EARTH, 1);
-			ThaumcraftApi.registerEntityTag("SpecialMobs.FireZombie", zombieAspects.add(Aspect.FIRE, 1));
-			ThaumcraftApi.registerEntityTag("SpecialMobs.FishingZombie", zombieAspects.add(Aspect.TOOL, 1));
-			ThaumcraftApi.registerEntityTag("SpecialMobs.GiantZombie", new AspectList().add(Aspect.UNDEAD, 4).add(Aspect.MAN, 2).add(Aspect.EARTH, 2));
-			ThaumcraftApi.registerEntityTag("SpecialMobs.HungryZombie", zombieAspects.add(Aspect.HUNGER, 1));
-			ThaumcraftApi.registerEntityTag("SpecialMobs.PlagueZombie", zombieAspects.add(Aspect.POISON, 1));
-			ThaumcraftApi.registerEntityTag("SpecialMobs.SpecialZombie", zombieAspects);
-			ThaumcraftApi.registerEntityTag("SpecialMobs.SteveZombie", zombieAspects.add(Aspect.MAN, 1));
-			
-			//ZOMBIE PIGMEN
-			AspectList zombiePigmanAspects = new AspectList().add(Aspect.UNDEAD, 4).add(Aspect.FIRE, 2);
-			ThaumcraftApi.registerEntityTag("SpecialMobs.AngryZombiePigman", zombiePigmanAspects.add(Aspect.ENTROPY, 1));
-			ThaumcraftApi.registerEntityTag("SpecialMobs.ChargingZombiePigman", zombiePigmanAspects.add(Aspect.ENERGY, 1));
-			ThaumcraftApi.registerEntityTag("SpecialMobs.FishingZombiePigman", zombiePigmanAspects.add(Aspect.TOOL, 1));
-			ThaumcraftApi.registerEntityTag("SpecialMobs.GiantZombiePigman", new AspectList().add(Aspect.UNDEAD, 6).add(Aspect.FIRE, 3));
-			ThaumcraftApi.registerEntityTag("SpecialMobs.HungryZombiePigman", zombiePigmanAspects.add(Aspect.HUNGER, 1));
-			ThaumcraftApi.registerEntityTag("SpecialMobs.JumpingZombiePigman", zombiePigmanAspects.add(Aspect.AIR, 1));
-			ThaumcraftApi.registerEntityTag("SpecialMobs.PlagueZombiePigman", zombiePigmanAspects.add(Aspect.POISON, 1));
-			ThaumcraftApi.registerEntityTag("SpecialMobs.SpecialZombiePigman", zombiePigmanAspects);
-			
-		}
-		
-	}	
-    
-    public static AspectList creatureAspects(int size, Aspect... aspects)
-    {
-    	return ThaumcraftMobAspects.creatureAspects(size, aspects);
-    }
+		// SKELETONS
+		AspectList skeletonAspects = new AspectList().add(Aspect.UNDEAD, 3).add(Aspect.MAN, 1).add(Aspect.EARTH, 1);
+		mobs.add(new ThaumcraftEntity("SpecialMobs.FireSkeleton", skeletonAspects.add(Aspect.FIRE, 1)));
+		mobs.add(new ThaumcraftEntity("SpecialMobs.GatlingSkeleton", skeletonAspects.add(Aspect.MECHANISM, 1)));
+		mobs.add(new ThaumcraftEntity("SpecialMobs.GiantSkeleton", new AspectList().add(Aspect.UNDEAD, 6)
+				.add(Aspect.MAN, 2).add(Aspect.EARTH, 2)));
+		mobs.add(new ThaumcraftEntity("SpecialMobs.PoisonSkeleton", skeletonAspects.add(Aspect.POISON, 1)));
+		mobs.add(new ThaumcraftEntity("SpecialMobs.QuickSkeleton", skeletonAspects.add(Aspect.MOTION, 1)));
+		mobs.add(new ThaumcraftEntity("SpecialMobs.SpecialSkeleton", skeletonAspects));
+		mobs.add(new ThaumcraftEntity("SpecialMobs.SpitfireSkeleton", skeletonAspects));
+		mobs.add(new ThaumcraftEntity("SpecialMobs.ThiefSkeleton", skeletonAspects.add(Aspect.GREED, 1)));
+
+		// SPIDERS
+		AspectList spiderAspects = new AspectList().add(Aspect.BEAST, 3).add(Aspect.ENTROPY, 2);
+		mobs.add(new ThaumcraftEntity("SpecialMobs.AngrySpider", spiderAspects.add(Aspect.ENTROPY, 1)));
+		mobs.add(new ThaumcraftEntity("SpecialMobs.ArmorSpider", spiderAspects.add(Aspect.ARMOR, 1)));
+		mobs.add(new ThaumcraftEntity("SpecialMobs.BabySpider", new AspectList().add(Aspect.BEAST, 1).add(
+				Aspect.ENTROPY, 1)));
+		mobs.add(new ThaumcraftEntity("SpecialMobs.DesertSpider", spiderAspects.add(Aspect.EARTH, 1)));
+		mobs.add(new ThaumcraftEntity("SpecialMobs.FlyingSpider", spiderAspects.add(Aspect.FLIGHT, 1)));
+		mobs.add(new ThaumcraftEntity("SpecialMobs.GiantSpider", new AspectList().add(Aspect.BEAST, 4).add(
+				Aspect.ENTROPY, 3)));
+		mobs.add(new ThaumcraftEntity("SpecialMobs.MotherSpider", spiderAspects.add(Aspect.HEAL, 1)));
+		mobs.add(new ThaumcraftEntity("SpecialMobs.PaleSpider", spiderAspects.add(Aspect.POISON, 1)));
+		mobs.add(new ThaumcraftEntity("SpecialMobs.PoisonSpider", spiderAspects.add(Aspect.POISON, 1)));
+		mobs.add(new ThaumcraftEntity("SpecialMobs.SmallSpider", new AspectList().add(Aspect.BEAST, 2).add(
+				Aspect.ENTROPY, 1)));
+		mobs.add(new ThaumcraftEntity("SpecialMobs.SpecialSpider", spiderAspects));
+		mobs.add(new ThaumcraftEntity("SpecialMobs.SpeedySpider", spiderAspects.add(Aspect.MOTION, 1)));
+		mobs.add(new ThaumcraftEntity("SpecialMobs.ToughSpider", spiderAspects.add(Aspect.LIFE, 1)));
+		mobs.add(new ThaumcraftEntity("SpecialMobs.WitchSpider", spiderAspects.add(Aspect.MAGIC, 1)));
+
+		// ZOMBIES
+		AspectList zombieAspects = new AspectList().add(Aspect.UNDEAD, 2).add(Aspect.MAN, 1).add(Aspect.EARTH, 1);
+		mobs.add(new ThaumcraftEntity("SpecialMobs.FireZombie", zombieAspects.add(Aspect.FIRE, 1)));
+		mobs.add(new ThaumcraftEntity("SpecialMobs.FishingZombie", zombieAspects.add(Aspect.TOOL, 1)));
+		mobs.add(new ThaumcraftEntity("SpecialMobs.GiantZombie", new AspectList().add(Aspect.UNDEAD, 4)
+				.add(Aspect.MAN, 2).add(Aspect.EARTH, 2)));
+		mobs.add(new ThaumcraftEntity("SpecialMobs.HungryZombie", zombieAspects.add(Aspect.HUNGER, 1)));
+		mobs.add(new ThaumcraftEntity("SpecialMobs.PlagueZombie", zombieAspects.add(Aspect.POISON, 1)));
+		mobs.add(new ThaumcraftEntity("SpecialMobs.SpecialZombie", zombieAspects));
+		mobs.add(new ThaumcraftEntity("SpecialMobs.SteveZombie", zombieAspects.add(Aspect.MAN, 1)));
+
+		// ZOMBIE PIGMEN
+		AspectList zombiePigmanAspects = new AspectList().add(Aspect.UNDEAD, 4).add(Aspect.FIRE, 2);
+		mobs.add(new ThaumcraftEntity("SpecialMobs.AngryZombiePigman", zombiePigmanAspects.add(Aspect.ENTROPY, 1)));
+		mobs.add(new ThaumcraftEntity("SpecialMobs.ChargingZombiePigman", zombiePigmanAspects.add(Aspect.ENERGY, 1)));
+		mobs.add(new ThaumcraftEntity("SpecialMobs.FishingZombiePigman", zombiePigmanAspects.add(Aspect.TOOL, 1)));
+		mobs.add(new ThaumcraftEntity("SpecialMobs.GiantZombiePigman", new AspectList().add(Aspect.UNDEAD, 6).add(
+				Aspect.FIRE, 3)));
+		mobs.add(new ThaumcraftEntity("SpecialMobs.HungryZombiePigman", zombiePigmanAspects.add(Aspect.HUNGER, 1)));
+		mobs.add(new ThaumcraftEntity("SpecialMobs.JumpingZombiePigman", zombiePigmanAspects.add(Aspect.AIR, 1)));
+		mobs.add(new ThaumcraftEntity("SpecialMobs.PlagueZombiePigman", zombiePigmanAspects.add(Aspect.POISON, 1)));
+		mobs.add(new ThaumcraftEntity("SpecialMobs.SpecialZombiePigman", zombiePigmanAspects));
+		return mobs;
+	}
+
+	public static AspectList creatureAspects(int size, Aspect... aspects)
+	{
+		return ThaumcraftMobAspects.creatureAspects(size, aspects);
+	}
 
 }

--- a/src/iguanaman/thaumcraftmobaspects/PluginTwilightForest.java
+++ b/src/iguanaman/thaumcraftmobaspects/PluginTwilightForest.java
@@ -1,75 +1,104 @@
 package iguanaman.thaumcraftmobaspects;
 
+import java.util.HashSet;
+
 import cpw.mods.fml.common.Loader;
 import thaumcraft.api.ThaumcraftApi;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
 
-public class PluginTwilightForest {
+public class PluginTwilightForest implements AspectPlugin {
 
-	public static void init()
+	@Override
+	public String[] getRequiredMods()
 	{
-
-		if (Loader.isModLoaded("TwilightForest"))
-		{
-			ThaumcraftApi.registerEntityTag("TwilightForest.Bighorn Sheep", creatureAspects(2, Aspect.EARTH));
-			ThaumcraftApi.registerEntityTag("TwilightForest.Block&Chain Goblin", creatureAspects(2, Aspect.EARTH).add(Aspect.WEAPON, 1).add(Aspect.ARMOR, 1));
-			//ThaumcraftApi.registerEntityTag("TwilightForest.Boggard", );
-			ThaumcraftApi.registerEntityTag("TwilightForest.Death Tome", new AspectList().add(Aspect.MIND, 3).add(Aspect.SOUL, 2).add(Aspect.TRAP, 1));
-			ThaumcraftApi.registerEntityTag("TwilightForest.Fire Beetle", creatureAspects(2, Aspect.FIRE));
-			ThaumcraftApi.registerEntityTag("TwilightForest.Firefly", creatureAspects(1, Aspect.AIR, Aspect.FLIGHT));
-			ThaumcraftApi.registerEntityTag("TwilightForest.Forest Bunny", creatureAspects(2, Aspect.EARTH));
-			ThaumcraftApi.registerEntityTag("TwilightForest.Forest Raven", creatureAspects(2, Aspect.AIR, Aspect.FLIGHT));
-			ThaumcraftApi.registerEntityTag("TwilightForest.Forest Squirrel", creatureAspects(2, Aspect.EARTH));
-			ThaumcraftApi.registerEntityTag("TwilightForest.Hedge Spider", new AspectList().add(Aspect.BEAST, 3).add(Aspect.ENTROPY, 2));
-			ThaumcraftApi.registerEntityTag("TwilightForest.Helmet Crab", creatureAspects(2, Aspect.EARTH, Aspect.WATER));
-			ThaumcraftApi.registerEntityTag("TwilightForest.Hostile Wolf", creatureAspects(3, Aspect.EARTH));
-			ThaumcraftApi.registerEntityTag("TwilightForest.Hydra", bossAspects(7, Aspect.ARMOR, Aspect.GREED));
-			ThaumcraftApi.registerEntityTag("TwilightForest.HydraHead", bossAspects(7, Aspect.WEAPON, Aspect.ENERGY, Aspect.MIND));
-			ThaumcraftApi.registerEntityTag("TwilightForest.King Spider", new AspectList().add(Aspect.BEAST, 6).add(Aspect.ENTROPY, 4));
-			//ThaumcraftApi.registerEntityTag("TwilightForest.Knight Phantom", );
-			ThaumcraftApi.registerEntityTag("TwilightForest.Lich Minion", new AspectList().add(Aspect.UNDEAD, 3).add(Aspect.MAN, 2).add(Aspect.EARTH, 2));
-			ThaumcraftApi.registerEntityTag("TwilightForest.Lower Goblin Knight", creatureAspects(2, Aspect.EARTH).add(Aspect.WEAPON, 1).add(Aspect.ARMOR, 1));
-			ThaumcraftApi.registerEntityTag("TwilightForest.Loyal Zombie", new AspectList().add(Aspect.UNDEAD, 3).add(Aspect.MAN, 2).add(Aspect.EARTH, 2));
-			ThaumcraftApi.registerEntityTag("TwilightForest.Maze Slime", new AspectList().add(Aspect.SLIME, 2).add(Aspect.WATER, 2));
-			ThaumcraftApi.registerEntityTag("TwilightForest.Mini Ghast", new AspectList().add(Aspect.UNDEAD, 2).add(Aspect.FIRE, 1));
-			ThaumcraftApi.registerEntityTag("TwilightForest.Minoshroom", bossAspects(6, Aspect.MAN, Aspect.BEAST, Aspect.PLANT, Aspect.GREED, Aspect.DARKNESS).add(Aspect.WEAPON, 1));
-			ThaumcraftApi.registerEntityTag("TwilightForest.Minotaur", creatureAspects(3, Aspect.EARTH).add(Aspect.WEAPON, 1));
-			ThaumcraftApi.registerEntityTag("TwilightForest.Mist Wolf", creatureAspects(3, Aspect.EARTH).add(Aspect.DARKNESS, 2));
-			ThaumcraftApi.registerEntityTag("TwilightForest.Mosquito Swarm", creatureAspects(1, Aspect.AIR, Aspect.FLIGHT));
-			ThaumcraftApi.registerEntityTag("TwilightForest.Naga", bossAspects(7, Aspect.BEAST, Aspect.POISON));
-			ThaumcraftApi.registerEntityTag("TwilightForest.Penguin", creatureAspects(3, Aspect.ICE).add(Aspect.WATER, 2));
-			ThaumcraftApi.registerEntityTag("TwilightForest.Pinch Beetle", creatureAspects(2, Aspect.EARTH).add(Aspect.WEAPON, 2));
-			ThaumcraftApi.registerEntityTag("TwilightForest.Questing Ram", creatureAspects(4, Aspect.EARTH).add(Aspect.CLOTH, 4));
-			ThaumcraftApi.registerEntityTag("TwilightForest.Redcap", creatureAspects(2, Aspect.EARTH).add(Aspect.METAL, 1));
-			ThaumcraftApi.registerEntityTag("TwilightForest.Redcap Sapper", creatureAspects(2, Aspect.EARTH).add(Aspect.METAL, 1));
-			ThaumcraftApi.registerEntityTag("TwilightForest.Redscale Broodling", creatureAspects(1, Aspect.ENTROPY));
-			ThaumcraftApi.registerEntityTag("TwilightForest.Skeleton Druid", new AspectList().add(Aspect.UNDEAD, 3).add(Aspect.MAN, 2).add(Aspect.EARTH, 1).add(Aspect.POISON, 1).add(Aspect.MAGIC, 1));
-			ThaumcraftApi.registerEntityTag("TwilightForest.Slime Beetle", creatureAspects(2, Aspect.SLIME));
-			ThaumcraftApi.registerEntityTag("TwilightForest.Swarm Spider", creatureAspects(1, Aspect.ENTROPY));
-			ThaumcraftApi.registerEntityTag("TwilightForest.Tiny Bird", creatureAspects(1, Aspect.AIR, Aspect.FLIGHT));
-			ThaumcraftApi.registerEntityTag("TwilightForest.Tower Boss", bossAspects(10, Aspect.UNDEAD, Aspect.FLIGHT, Aspect.ENTROPY));
-			ThaumcraftApi.registerEntityTag("TwilightForest.Tower Ghast", new AspectList().add(Aspect.UNDEAD, 3).add(Aspect.FIRE, 2));
-			ThaumcraftApi.registerEntityTag("TwilightForest.Tower Golem", new AspectList().add(Aspect.METAL, 4).add(Aspect.EARTH, 3));
-			ThaumcraftApi.registerEntityTag("TwilightForest.Tower Termite", creatureAspects(1, Aspect.EARTH));
-			ThaumcraftApi.registerEntityTag("TwilightForest.Twilight Kobold", creatureAspects(2, Aspect.EARTH));
-			ThaumcraftApi.registerEntityTag("TwilightForest.Twilight Lich", bossAspects(10, Aspect.UNDEAD, Aspect.MAGIC, Aspect.MIND));
-			ThaumcraftApi.registerEntityTag("TwilightForest.Twilight Wraith", new AspectList().add(Aspect.SOUL, 3).add(Aspect.GREED, 3).add(Aspect.DARKNESS, 2));
-			ThaumcraftApi.registerEntityTag("TwilightForest.Upper Goblin Knight", creatureAspects(2, Aspect.EARTH).add(Aspect.WEAPON, 1).add(Aspect.ARMOR, 1));
-			ThaumcraftApi.registerEntityTag("TwilightForest.Wild Boar", creatureAspects(2, Aspect.EARTH).add(Aspect.WEAPON, 1));
-			ThaumcraftApi.registerEntityTag("TwilightForest.Wild Deer", creatureAspects(2, Aspect.EARTH));
-		}
-		
+		return new String[]
+		{ "TwilightForest" };
 	}
-    
-    public static AspectList creatureAspects(int size, Aspect... aspects)
-    {
-    	return ThaumcraftMobAspects.creatureAspects(size, aspects);
-    }
-    
-    public static AspectList bossAspects(int amount, Aspect... aspects)
-    {
-    	return ThaumcraftMobAspects.bossAspects(amount, aspects);
-    }
 
+	@Override
+	public HashSet<ThaumcraftEntity> getThaumcraftMobs()
+	{
+		HashSet<ThaumcraftEntity> mobs = new HashSet<ThaumcraftEntity>();
+		mobs.add(new ThaumcraftEntity("TwilightForest.Bighorn Sheep", creatureAspects(2, Aspect.EARTH)));
+		mobs.add(new ThaumcraftEntity("TwilightForest.Block&Chain Goblin", creatureAspects(2, Aspect.EARTH).add(
+				Aspect.WEAPON, 1).add(Aspect.ARMOR, 1)));
+		// mobs.add(new ThaumcraftMob("TwilightForest.Boggard", );
+		mobs.add(new ThaumcraftEntity("TwilightForest.Death Tome", new AspectList().add(Aspect.MIND, 3)
+				.add(Aspect.SOUL, 2).add(Aspect.TRAP, 1)));
+		mobs.add(new ThaumcraftEntity("TwilightForest.Fire Beetle", creatureAspects(2, Aspect.FIRE)));
+		mobs.add(new ThaumcraftEntity("TwilightForest.Firefly", creatureAspects(1, Aspect.AIR, Aspect.FLIGHT)));
+		mobs.add(new ThaumcraftEntity("TwilightForest.Forest Bunny", creatureAspects(2, Aspect.EARTH)));
+		mobs.add(new ThaumcraftEntity("TwilightForest.Forest Raven", creatureAspects(2, Aspect.AIR, Aspect.FLIGHT)));
+		mobs.add(new ThaumcraftEntity("TwilightForest.Forest Squirrel", creatureAspects(2, Aspect.EARTH)));
+		mobs.add(new ThaumcraftEntity("TwilightForest.Hedge Spider", new AspectList().add(Aspect.BEAST, 3).add(
+				Aspect.ENTROPY, 2)));
+		mobs.add(new ThaumcraftEntity("TwilightForest.Helmet Crab", creatureAspects(2, Aspect.EARTH, Aspect.WATER)));
+		mobs.add(new ThaumcraftEntity("TwilightForest.Hostile Wolf", creatureAspects(3, Aspect.EARTH)));
+		mobs.add(new ThaumcraftEntity("TwilightForest.Hydra", bossAspects(7, Aspect.ARMOR, Aspect.GREED)));
+		mobs.add(new ThaumcraftEntity("TwilightForest.HydraHead", bossAspects(7, Aspect.WEAPON, Aspect.ENERGY,
+				Aspect.MIND)));
+		mobs.add(new ThaumcraftEntity("TwilightForest.King Spider", new AspectList().add(Aspect.BEAST, 6).add(
+				Aspect.ENTROPY, 4)));
+		// mobs.add(new ThaumcraftMob("TwilightForest.Knight Phantom", );
+		mobs.add(new ThaumcraftEntity("TwilightForest.Lich Minion", new AspectList().add(Aspect.UNDEAD, 3)
+				.add(Aspect.MAN, 2).add(Aspect.EARTH, 2)));
+		mobs.add(new ThaumcraftEntity("TwilightForest.Lower Goblin Knight", creatureAspects(2, Aspect.EARTH).add(
+				Aspect.WEAPON, 1).add(Aspect.ARMOR, 1)));
+		mobs.add(new ThaumcraftEntity("TwilightForest.Loyal Zombie", new AspectList().add(Aspect.UNDEAD, 3)
+				.add(Aspect.MAN, 2).add(Aspect.EARTH, 2)));
+		mobs.add(new ThaumcraftEntity("TwilightForest.Maze Slime", new AspectList().add(Aspect.SLIME, 2).add(
+				Aspect.WATER, 2)));
+		mobs.add(new ThaumcraftEntity("TwilightForest.Mini Ghast", new AspectList().add(Aspect.UNDEAD, 2).add(
+				Aspect.FIRE, 1)));
+		mobs.add(new ThaumcraftEntity("TwilightForest.Minoshroom", bossAspects(6, Aspect.MAN, Aspect.BEAST,
+				Aspect.PLANT, Aspect.GREED, Aspect.DARKNESS).add(Aspect.WEAPON, 1)));
+		mobs.add(new ThaumcraftEntity("TwilightForest.Minotaur", creatureAspects(3, Aspect.EARTH).add(Aspect.WEAPON, 1)));
+		mobs.add(new ThaumcraftEntity("TwilightForest.Mist Wolf", creatureAspects(3, Aspect.EARTH).add(Aspect.DARKNESS,
+				2)));
+		mobs.add(new ThaumcraftEntity("TwilightForest.Mosquito Swarm", creatureAspects(1, Aspect.AIR, Aspect.FLIGHT)));
+		mobs.add(new ThaumcraftEntity("TwilightForest.Naga", bossAspects(7, Aspect.BEAST, Aspect.POISON)));
+		mobs.add(new ThaumcraftEntity("TwilightForest.Penguin", creatureAspects(3, Aspect.ICE).add(Aspect.WATER, 2)));
+		mobs.add(new ThaumcraftEntity("TwilightForest.Pinch Beetle", creatureAspects(2, Aspect.EARTH).add(
+				Aspect.WEAPON, 2)));
+		mobs.add(new ThaumcraftEntity("TwilightForest.Questing Ram", creatureAspects(4, Aspect.EARTH).add(Aspect.CLOTH,
+				4)));
+		mobs.add(new ThaumcraftEntity("TwilightForest.Redcap", creatureAspects(2, Aspect.EARTH).add(Aspect.METAL, 1)));
+		mobs.add(new ThaumcraftEntity("TwilightForest.Redcap Sapper", creatureAspects(2, Aspect.EARTH).add(
+				Aspect.METAL, 1)));
+		mobs.add(new ThaumcraftEntity("TwilightForest.Redscale Broodling", creatureAspects(1, Aspect.ENTROPY)));
+		mobs.add(new ThaumcraftEntity("TwilightForest.Skeleton Druid", new AspectList().add(Aspect.UNDEAD, 3)
+				.add(Aspect.MAN, 2).add(Aspect.EARTH, 1).add(Aspect.POISON, 1).add(Aspect.MAGIC, 1)));
+		mobs.add(new ThaumcraftEntity("TwilightForest.Slime Beetle", creatureAspects(2, Aspect.SLIME)));
+		mobs.add(new ThaumcraftEntity("TwilightForest.Swarm Spider", creatureAspects(1, Aspect.ENTROPY)));
+		mobs.add(new ThaumcraftEntity("TwilightForest.Tiny Bird", creatureAspects(1, Aspect.AIR, Aspect.FLIGHT)));
+		mobs.add(new ThaumcraftEntity("TwilightForest.Tower Boss", bossAspects(10, Aspect.UNDEAD, Aspect.FLIGHT,
+				Aspect.ENTROPY)));
+		mobs.add(new ThaumcraftEntity("TwilightForest.Tower Ghast", new AspectList().add(Aspect.UNDEAD, 3).add(
+				Aspect.FIRE, 2)));
+		mobs.add(new ThaumcraftEntity("TwilightForest.Tower Golem", new AspectList().add(Aspect.METAL, 4).add(
+				Aspect.EARTH, 3)));
+		mobs.add(new ThaumcraftEntity("TwilightForest.Tower Termite", creatureAspects(1, Aspect.EARTH)));
+		mobs.add(new ThaumcraftEntity("TwilightForest.Twilight Kobold", creatureAspects(2, Aspect.EARTH)));
+		mobs.add(new ThaumcraftEntity("TwilightForest.Twilight Lich", bossAspects(10, Aspect.UNDEAD, Aspect.MAGIC,
+				Aspect.MIND)));
+		mobs.add(new ThaumcraftEntity("TwilightForest.Twilight Wraith", new AspectList().add(Aspect.SOUL, 3)
+				.add(Aspect.GREED, 3).add(Aspect.DARKNESS, 2)));
+		mobs.add(new ThaumcraftEntity("TwilightForest.Upper Goblin Knight", creatureAspects(2, Aspect.EARTH).add(
+				Aspect.WEAPON, 1).add(Aspect.ARMOR, 1)));
+		mobs.add(new ThaumcraftEntity("TwilightForest.Wild Boar", creatureAspects(2, Aspect.EARTH)
+				.add(Aspect.WEAPON, 1)));
+		mobs.add(new ThaumcraftEntity("TwilightForest.Wild Deer", creatureAspects(2, Aspect.EARTH)));
+		return mobs;
+	}
+
+	public static AspectList creatureAspects(int size, Aspect... aspects)
+	{
+		return ThaumcraftMobAspects.creatureAspects(size, aspects);
+	}
+
+	public static AspectList bossAspects(int amount, Aspect... aspects)
+	{
+		return ThaumcraftMobAspects.bossAspects(amount, aspects);
+	}
 }

--- a/src/iguanaman/thaumcraftmobaspects/ThaumcraftEntity.java
+++ b/src/iguanaman/thaumcraftmobaspects/ThaumcraftEntity.java
@@ -1,0 +1,48 @@
+package iguanaman.thaumcraftmobaspects;
+
+import java.util.HashMap;
+import java.util.Map.Entry;
+
+import thaumcraft.api.aspects.Aspect;
+import thaumcraft.api.aspects.AspectList;
+
+public class ThaumcraftEntity {
+
+	public final String _HEADER = "*****************************************";
+	public final String entityName;
+	public final String _FOOTER = "*****************************************";
+	public final String _COMMENT = "Aspects are in the form aspect : value ";
+	public final HashMap<String, Integer> aspects;
+
+	public ThaumcraftEntity(String entityName)
+	{
+		this.entityName = entityName;
+		this.aspects = new HashMap<String, Integer>(0);
+	}
+
+	public ThaumcraftEntity(String entityName, AspectList aspectList)
+	{
+		this.entityName = entityName;
+		this.aspects = new HashMap<String, Integer>(aspectList.aspects.size());
+		for (Entry<Aspect, Integer> entry : aspectList.aspects.entrySet())
+		{
+			this.aspects.put(entry.getKey().getTag(), entry.getValue());
+		}
+	}
+
+	@Override
+	public boolean equals(Object obj)
+	{
+		if (obj == null || !(obj instanceof ThaumcraftEntity))
+		{
+			return false;
+		}
+		return entityName.equals(((ThaumcraftEntity) obj).entityName);
+	}
+
+	@Override
+	public int hashCode()
+	{
+		return entityName.hashCode();
+	}
+}

--- a/src/iguanaman/thaumcraftmobaspects/ThaumcraftMobAspects.java
+++ b/src/iguanaman/thaumcraftmobaspects/ThaumcraftMobAspects.java
@@ -1,37 +1,18 @@
 package iguanaman.thaumcraftmobaspects;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.List;
-import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.Reader;
+import java.io.Writer;
+import java.util.HashSet;
+import java.util.Map.Entry;
+import java.util.Set;
 
-import net.minecraft.block.Block;
-import net.minecraft.block.BlockGravel;
-import net.minecraft.block.BlockSilverfish;
-import net.minecraft.block.material.Material;
-import net.minecraft.command.ICommandManager;
-import net.minecraft.command.ServerCommandManager;
-import net.minecraft.creativetab.CreativeTabs;
-import net.minecraft.entity.EntityLiving;
-import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.item.Item;
-import net.minecraft.item.ItemBucket;
-import net.minecraft.item.ItemBucketMilk;
-import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NBTBase;
-import net.minecraft.potion.Potion;
-import net.minecraft.src.ModLoader;
-import net.minecraftforge.common.ConfigCategory;
-import net.minecraftforge.common.Configuration;
-import net.minecraftforge.common.ForgeHooks;
-import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.common.Property;
-import net.minecraftforge.oredict.OreDictionary;
-import net.minecraftforge.oredict.ShapedOreRecipe;
+import net.minecraft.entity.EntityList;
 
 import org.modstats.ModstatInfo;
 import org.modstats.Modstats;
@@ -41,74 +22,179 @@ import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
 
 import com.google.common.base.Optional;
+import com.google.common.collect.HashMultimap;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 
-import cpw.mods.fml.common.FMLLog;
 import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.Mod;
 import cpw.mods.fml.common.Mod.EventHandler;
-import cpw.mods.fml.common.Mod.Init;
 import cpw.mods.fml.common.Mod.Instance;
-import cpw.mods.fml.common.Mod.PostInit;
-import cpw.mods.fml.common.Mod.PreInit;
-import cpw.mods.fml.common.Mod.ServerStarting;
-import cpw.mods.fml.common.SidedProxy;
-import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
-import cpw.mods.fml.common.event.FMLServerStartedEvent;
-import cpw.mods.fml.common.event.FMLServerStartingEvent;
 import cpw.mods.fml.common.network.NetworkMod;
-import cpw.mods.fml.common.registry.GameRegistry;
-import cpw.mods.fml.common.registry.LanguageRegistry;
-import cpw.mods.fml.common.registry.TickRegistry;
-import cpw.mods.fml.relauncher.Side;
 
 @Mod(modid="ThaumcraftMobAspects", name="Thaumcraft Mob Aspects", version="1.6.X-1b", 
 dependencies="required-after:Thaumcraft;after:MoCreatures;after:LycanitesMobs;after:SpecialMobs")
 @NetworkMod(clientSideRequired=true, serverSideRequired=true)
 @ModstatInfo(prefix="tcmobaspec")
 public class ThaumcraftMobAspects {
-	
+    
     // The instance of your mod that Forge uses.
     @Instance("ThaumcraftMobAspects")
     public static ThaumcraftMobAspects instance;
-
-    @EventHandler
-    public void load(FMLInitializationEvent event) {
-    	Modstats.instance().getReporter().registerMod(this);
-
-		ThaumcraftApi.registerEntityTag("the_iguana_man", bossAspects(5, Aspect.MAN, Aspect.MIND, Aspect.SOUL, Aspect.LIFE, Aspect.MAGIC, Aspect.ELDRITCH, Aspect.ENERGY, Aspect.HUNGER));
-		ThaumcraftApi.registerEntityTag("XanderGryphon", bossAspects(5, Aspect.MAN, Aspect.MIND, Aspect.SOUL, Aspect.LIFE, Aspect.MAGIC, Aspect.ELDRITCH, Aspect.ENERGY, Aspect.HUNGER));
-		
-		PluginLycanitesMobs.init();
-		PluginMoCreatures.init();
-		PluginSpecialMobs.init();
-		PluginTwilightForest.init();
-		
-    }
     
-    public static AspectList creatureAspects(int size, Aspect... aspects)
-    {
-    	int sizeMod =  Math.max(Math.round((float)size / (float)aspects.length), 1);
-    	AspectList result =  new AspectList().add(Aspect.BEAST, size);
-    	for (Aspect aspect : aspects) result.add(aspect, sizeMod);
-    	return result;
-    }
-    
-    public static AspectList bossAspects(int amount, Aspect... aspects)
-    {
-    	AspectList result =  new AspectList()
-    	.add(Aspect.EARTH, amount)
-    	.add(Aspect.AIR, amount)
-    	.add(Aspect.FIRE, amount)
-    	.add(Aspect.ENTROPY, amount)
-    	.add(Aspect.WATER, amount)
-    	.add(Aspect.ORDER, amount)
-    	;
-    	
-    	for (Aspect aspect : aspects) result.add(aspect, amount);
-    	
-    	return result;
-    }
-	
+	private File configDirectory;
+
+	@EventHandler
+	public void pre(FMLPreInitializationEvent event)
+	{
+		configDirectory = event.getModConfigurationDirectory();
+	}
+
+	@EventHandler
+	public void post(FMLPostInitializationEvent event)
+	{
+		Modstats.instance().getReporter().registerMod(this);
+
+		ModFileCache files = new ModFileCache(configDirectory);
+		HashSet<String> modIds = files.getModIds();
+
+		HashMultimap<String, ThaumcraftEntity> modIdToMobs = HashMultimap.create();
+		// Read Entries from Configuration Files
+		for (String modId : modIds)
+		{
+			Optional<File> file = files.getFile(modId);
+			if (file.isPresent())
+			{
+				readFromFile(file.get(), modIdToMobs.get(modId));
+			}
+		}
+
+		// Add Default Values that may not be in files
+		modIdToMobs.put(
+				ModFileCache.PLAYER_CATEGORY,
+				new ThaumcraftEntity("the_iguana_man", bossAspects(5, Aspect.MAN, Aspect.MIND, Aspect.SOUL,
+						Aspect.LIFE, Aspect.MAGIC, Aspect.ELDRITCH, Aspect.ENERGY, Aspect.HUNGER)));
+		modIdToMobs.put(
+				ModFileCache.PLAYER_CATEGORY,
+				new ThaumcraftEntity("XanderGryphon", bossAspects(5, Aspect.MAN, Aspect.MIND, Aspect.SOUL, Aspect.LIFE,
+						Aspect.MAGIC, Aspect.ELDRITCH, Aspect.ENERGY, Aspect.HUNGER)));
+
+		AspectPlugin[] plugins = new AspectPlugin[]
+		{ new PluginLycanitesMobs(), new PluginMoCreatures(), new PluginSpecialMobs(), new PluginTwilightForest() };
+		for (AspectPlugin aspectPlugin : plugins)
+		{
+			if (shouldLoadPlugin(aspectPlugin))
+			{
+				for (ThaumcraftEntity mob : aspectPlugin.getThaumcraftMobs())
+				{
+					modIdToMobs.put(files.guessModId(mob.entityName), mob);
+				}
+			}
+		}
+
+		// Add Generic Entities that have no values
+		for (Object object : EntityList.stringToClassMapping.keySet())
+		{
+			String entityName = (String) object;
+			modIdToMobs.put(files.guessModId(entityName), new ThaumcraftEntity(entityName));
+		}
+
+		// Write All Entries to File
+		for (String modId : modIdToMobs.keySet())
+		{
+			Optional<File> file = files.getFile(modId);
+			if (file.isPresent())
+			{
+				saveToFile(file.get(), modIdToMobs.get(modId));
+			}
+		}
+
+		// Register valid, non-empty entries with our Thaumcraft overlord
+		for (ThaumcraftEntity mob : modIdToMobs.values())
+		{
+			AspectList aspectList = new AspectList();
+			for (Entry<String, Integer> entry : mob.aspects.entrySet())
+			{
+				Aspect aspect = Aspect.aspects.get(entry.getKey());
+				if (aspect != null)
+				{
+					aspectList.add(aspect, entry.getValue());
+				}
+			}
+			if (aspectList.size() > 0)
+			{
+				ThaumcraftApi.registerEntityTag(mob.entityName, aspectList);
+			}
+		}
+	}
+
+	private boolean shouldLoadPlugin(AspectPlugin plugin)
+	{
+		for (String modID : plugin.getRequiredMods())
+		{
+			if (!Loader.isModLoaded(modID))
+			{
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private void readFromFile(File configFile, Set<ThaumcraftEntity> mobs)
+	{
+		try
+		{
+			Reader reader = new InputStreamReader(new FileInputStream(configFile));
+			Gson gson = new GsonBuilder().create();
+			// Array is required as GSON seems to have trouble with MultiMapSet
+			ThaumcraftEntity[] readMobs = gson.fromJson(reader, ThaumcraftEntity[].class);
+			if (readMobs != null)
+			{
+				for (ThaumcraftEntity thaumcraftMob : readMobs)
+				{
+					mobs.add(thaumcraftMob);
+				}
+			}
+		} catch (IOException e)
+		{
+			e.printStackTrace();
+		}
+	}
+
+	private void saveToFile(File configFile, Set<ThaumcraftEntity> mobs)
+	{
+		Gson gson = new GsonBuilder().setPrettyPrinting().create();
+		try
+		{
+			Writer output = new OutputStreamWriter(new FileOutputStream(configFile));
+			gson.toJson(mobs, output);
+			output.close();
+		} catch (IOException e1)
+		{
+			e1.printStackTrace();
+		}
+	}
+
+	public static AspectList creatureAspects(int size, Aspect... aspects)
+	{
+		int sizeMod = Math.max(Math.round((float) size / (float) aspects.length), 1);
+		AspectList result = new AspectList().add(Aspect.BEAST, size);
+		for (Aspect aspect : aspects)
+			result.add(aspect, sizeMod);
+		return result;
+	}
+
+	public static AspectList bossAspects(int amount, Aspect... aspects)
+	{
+		AspectList result = new AspectList().add(Aspect.EARTH, amount).add(Aspect.AIR, amount).add(Aspect.FIRE, amount)
+				.add(Aspect.ENTROPY, amount).add(Aspect.WATER, amount).add(Aspect.ORDER, amount);
+
+		for (Aspect aspect : aspects)
+			result.add(aspect, amount);
+
+		return result;
+	}
+
 }


### PR DESCRIPTION
Provides support for Configuration Aspects. ThaumcraftEntity is a generic object for wrapping read/write friendly aspects for each entity.
Configuration is under Config/ThaumcraftMobAspects. Each entity is divided into categories (based on ModID) with a seperate file for each.
Example groups: vanilla, vanillaitems, unknown.

Players are currently placed into 'unknown' as EntityList does not contain a player entity there is no way to know if the entity doesn't exist or is a player.
NBT support could be added by adding a NBT array object in ThaumcraftEntity. AFAIK, GSON is perfectly happy ignoring non-existent fields so its easily optional.

JSON does not allow comments: everything must be data. Comments in the configs are handled by actually placing them in the Java fields, i.e. _HEADER, _FOOTER, and _COMMENT.

Moved registration from load to post to allow for entities to registration. I can't see any benefit to doing it earlier, but can be easily reverted if desired. I feel I should note that the  "required-after:Thaumcraft;after:MoCreatures;after:LycanitesMobs;after:SpecialMobs" could be changed to the more generic "required-after:*" to be the last one to load.

DISCLAIMER: Never tested outside eclipse. This was a useful test case to see how GSON handles and get a feel for the workflow. As such testing outside file read/writing are practically non-existent.
